### PR TITLE
docs: fix ollama q4 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ ollama create gelab-zero-4b-preview -f Modelfile
 ollama create -q q8_0 gelab-zero-4b-preview 
 
 # Quantize the model with int4 precision (large precision loss, model size becomes 2.2G):
-ollama create -q q4_0 gelab-zero-4b-preview
+ollama create -q Q4_K_M gelab-zero-4b-preview
 
 # Revert to the original precision:
 ollama create -q f16 gelab-zero-4b-preview

--- a/README_CN.md
+++ b/README_CN.md
@@ -282,7 +282,7 @@ ollama create gelab-zero-4b-preview -f Modelfile
 ollama create -q q8_0 gelab-zero-4b-preview 
 
 # 使用int4 精度量化模型（精度损失较大，模型尺寸变为2.2G ）：
-ollama create -q q4_0 gelab-zero-4b-preview
+ollama create -q Q4_K_M gelab-zero-4b-preview
 
 # 换回原始精度：
 ollama create -q f16 gelab-zero-4b-preview


### PR DESCRIPTION
Fix Ollama quantization instructions by replacing the unsupported q4_0 with the supported Q4_K_M in both READMEs.

因为在ollama中直接量化q4的时候会报错：converting model 
Error: unsupported quantization type Q4_0 - supported types are F32, F16, Q4_K_S, Q4_K_M, Q8_0

于是修正了文档中的 Ollama 量化命令，将不受支持的 q4_0 替换为受支持的 Q4_K_M（更新了中英文 README）