### PR TITLE
Fix: `Pop`/`Abort`/`Complete` action handling to avoid invalid ADB execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config.yaml
 */*.pyc
+__pycache__/
 tmp_screenshot
 output/
 running_log

--- a/copilot_front_end/mobile_action_helper.py
+++ b/copilot_front_end/mobile_action_helper.py
@@ -568,7 +568,9 @@ def act_on_device(device_id, action, print_command = False, refush_app = True, d
         adb_command += f' shell app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -keyboard "{text}"'
 
     elif action['action_type'] == "Pop":
-        pass
+        if print_command:
+            print("Pop action received; no device command executed.")
+        return
 
     elif action['action_type'] == "Wait":
         wait_time = action['args']['duration']
@@ -598,13 +600,18 @@ def act_on_device(device_id, action, print_command = False, refush_app = True, d
         adb_command += f" shell app_process -Djava.class.path=/data/local/tmp/yadb /data/local/tmp com.ysbing.yadb.Main -touch {point[0]} {point[1]} 2000"
 
     elif action['action_type'] == "Abort":
-
-        pass
+        if print_command:
+            abort_reason = action.get('args', {}).get('abort_reason')
+            if abort_reason:
+                print(f"Abort action received: {abort_reason}")
+            else:
+                print("Abort action received.")
+        return
 
     elif action['action_type'] == "Complete":
-
-        pass
-
+        if print_command:
+            print("Complete action received.")
+        return
 
     else:
         raise ValueError(f"Invalid action type: {action['action_type']}")


### PR DESCRIPTION
## 摘要
此 PR 修复了 `copilot_front_end/mobile_action_helper.py`，使前端动作类型 `Pop`、`Abort` 和 `Complete` 不再发生贯穿（fall through）并尝试执行不完整的 `adb` 命令。

## 问题
此前，`act_on_device()` 对这些动作类型仅使用 `pass` 处理，随后仍会继续进入公共执行逻辑并运行 `subprocess.run(adb_command, ...)`。此时 `adb_command` 可能仅为 `adb` / `adb -s <device>`（没有子命令），从而导致静默失败并引发令人困惑的行为。

## 变更
- `Pop`：提前返回（可选记录日志），不执行设备命令。
- `Abort`：提前返回，并在可用时记录 `abort_reason`。
- `Complete`：提前返回（可选记录日志），不执行设备命令。
- 同时在 `.gitignore` 中忽略 `__pycache__/`，避免本地运行时产生意外的未跟踪噪音文件。

## 测试
- 本地导入冒烟测试：`python -c "import copilot_front_end.mobile_action_helper as m; print('ok')"`