### PR TITLE
Fix prompt suffix that may mix with user instruction.

### DIFF
--- a/copilot_tools/parser_0920_summary.py
+++ b/copilot_tools/parser_0920_summary.py
@@ -65,7 +65,7 @@ def make_status_prompt(task, current_image, hints, summary_history="", user_comm
         history_display = summary_history + user_comment if summary_history.strip() else "暂无历史操作"
 
     user_instruction = f'''\n\n{user_comment}\n\n''' if user_comment != "" else ""
-    task = task + user_instruction + "指令结束\n\n"
+    task = task + user_instruction + "\n指令结束\n\n"
 
     
     status_conversation = [


### PR DESCRIPTION
直接在后面增加指令结束，可能会造成歧义。

修改前：

```
Step 1/400 done. Action: OrderedDict({'cot': '我看到的是手机主屏幕。任务是“打开QQ指令结束”。这个指令有点模糊，但最合理的解释是“打开QQ应用”。因此，我的第一步是启动QQ。我将使用`AWAKE`动作来打开QQ应用。执行后，我预期会看到QQ的主界面。', 'explain': '我需要先打开QQ应用，才能执行后续的指令操作。', 'action': 'AWAKE', 'value': 'QQ', 'summary': '任务目标是打开QQ并执行指令。当前正在执行第一步：打开QQ应用。', 'action_type': 'AWAKE'})
LLM gelab-zero-4b-preview inference time: 6.04 seconds
llm ask id: chatcmpl-210
Step 2 took: 6.06 seconds
Executing command: adb -s fb7bdbc shell input tap 1003.32 184.8
Step 2/400 done. Action: OrderedDict({'cot': '我看到当前界面是QQ的消息列表。任务目标是执行一个指令。通常，这类指令功能位于应用的主 菜单或设置中。在QQ的界面布局中，右上角的加号图标是进入更多功能的入口。因此，我认为下一步应该点击这个加号图标，以查找并执行指令。点 击后，我预期会看到一个包含各种功能选项的菜单。', 'explain': '我需要点击右上角的加号图标，这是访问QQ更多功能和指令的常见入口。'
```

修改后：
```
Step 1/400 done. Action: OrderedDict({'cot': '我看到的是手机主屏幕。任务是打开QQ。我观察到屏幕左下角有一个QQ应用的图标，它是一个戴着红色围巾的企鹅。为了打开QQ，我需要点击这个图标。点击后，我预期QQ应用会启动并显示其主界面。', 'explain': '我需要点击QQ应用图标来启动它，以完成打开QQ的任务。', 'action': 'CLICK', 'point': [148, 837], 'summary': '任务目标是打开QQ。当前正在尝试通过点击主屏幕上的QQ图标来启动应用。', 'action_type': 'CLICK'})
LLM gelab-zero-4b-preview inference time: 5.05 seconds
llm ask id: chatcmpl-116
Step 2 took: 18.06 seconds
Task completed.
Step 2/400 done. Action: OrderedDict({'cot': '我看到当前界面是QQ的消息列表页，这表明QQ应用已经成功打开。任务目标是“打开QQ”，这个目标已经达成。因此，我认为现在应该结束任务。', 'explain': '我已经成 功打开了QQ应用，任务目标已经完成。', 'action': 'COMPLETE', 'return': '我已成功打开QQ应用。', 'summary': '任务目标是打开QQ。该任务已成功完成，当前界面显示QQ应用已打开。', 'action_type': 'COMPLETE'})
Task 打开QQ done in 2 steps. Session ID: 0268ea8d-45ee-422d-8c75-cdc1fc33f53e
总计执行时间为 107.18476557731628 秒
```