### PR TITLE
feat: add LiteLLM as LLM provider

### DIFF
--- a/model_config.yaml
+++ b/model_config.yaml
@@ -5,3 +5,7 @@ local:
 stepfun:
     api_base: "https://api.stepfun.com/v1"
     api_key: "EMPTY"
+
+litellm:
+    api_base: "EMPTY"
+    api_key: "EMPTY"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ uvicorn
 
 pymongo
 openai==2.28.0
+litellm>=1.60.0,<2.0.0
 
 pandas
 Pillow

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -27,11 +27,11 @@ class TestLiteLLMCodePath:
 
     def test_uses_litellm_completion(self):
         src = ASK_LLM_PATH.read_text()
-        assert "_litellm.completion(" in src
+        assert "litellm.completion(" in src
 
-    def test_lazy_imports_litellm(self):
+    def test_imports_litellm_at_top(self):
         src = ASK_LLM_PATH.read_text()
-        assert "import litellm as _litellm" in src
+        assert "import litellm" in src.split("def ")[0]
 
     def test_skips_empty_api_key(self):
         src = ASK_LLM_PATH.read_text()

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,133 @@
+"""Unit tests for LiteLLM provider integration in ask_llm_v2."""
+
+import ast
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+
+ASK_LLM_PATH = Path(__file__).resolve().parents[1] / "tools" / "ask_llm_v2.py"
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "model_config.yaml"
+
+
+class TestLiteLLMCodePath:
+    """Verify the litellm branch exists in ask_llm_v2.py source."""
+
+    def test_litellm_branch_exists(self):
+        src = ASK_LLM_PATH.read_text()
+        assert 'model_provider == "litellm"' in src
+
+    def test_uses_drop_params_true(self):
+        src = ASK_LLM_PATH.read_text()
+        assert '"drop_params": True' in src or "'drop_params': True" in src
+
+    def test_uses_litellm_completion(self):
+        src = ASK_LLM_PATH.read_text()
+        assert "_litellm.completion(" in src
+
+    def test_lazy_imports_litellm(self):
+        src = ASK_LLM_PATH.read_text()
+        assert "import litellm as _litellm" in src
+
+    def test_skips_empty_api_key(self):
+        src = ASK_LLM_PATH.read_text()
+        assert 'api_key != "EMPTY"' in src
+
+    def test_skips_empty_api_base(self):
+        src = ASK_LLM_PATH.read_text()
+        assert 'api_base != "EMPTY"' in src
+
+
+class TestModelConfig:
+    """Verify model_config.yaml has litellm entry."""
+
+    def test_litellm_in_config(self):
+        with open(CONFIG_PATH, "r") as f:
+            config = yaml.safe_load(f)
+        assert "litellm" in config
+
+    def test_litellm_config_has_api_base(self):
+        with open(CONFIG_PATH, "r") as f:
+            config = yaml.safe_load(f)
+        assert "api_base" in config["litellm"]
+
+    def test_litellm_config_has_api_key(self):
+        with open(CONFIG_PATH, "r") as f:
+            config = yaml.safe_load(f)
+        assert "api_key" in config["litellm"]
+
+
+class TestLiteLLMSDKCall:
+    """Test litellm SDK call pattern directly (no module import needed)."""
+
+    def test_completion_called_with_drop_params(self):
+        fake = types.ModuleType("litellm")
+        mock_msg = MagicMock(content="4", reasoning_content=None, reasoning=None)
+        mock_resp = MagicMock(
+            choices=[MagicMock(message=mock_msg)],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            id="test-id",
+        )
+        fake.completion = MagicMock(return_value=mock_resp)
+        sys.modules["litellm"] = fake
+
+        try:
+            fake.completion(
+                model="anthropic/claude-sonnet-4-20250514",
+                messages=[{"role": "user", "content": "2+2?"}],
+                drop_params=True,
+                temperature=0.5,
+                max_tokens=100,
+            )
+            kwargs = fake.completion.call_args.kwargs
+            assert kwargs["model"] == "anthropic/claude-sonnet-4-20250514"
+            assert kwargs["drop_params"] is True
+        finally:
+            del sys.modules["litellm"]
+
+    def test_completion_forwards_api_key(self):
+        fake = types.ModuleType("litellm")
+        mock_msg = MagicMock(content="ok", reasoning_content=None, reasoning=None)
+        mock_resp = MagicMock(
+            choices=[MagicMock(message=mock_msg)],
+            usage=MagicMock(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+            id="test-id",
+        )
+        fake.completion = MagicMock(return_value=mock_resp)
+        sys.modules["litellm"] = fake
+
+        try:
+            fake.completion(
+                model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                api_key="sk-test",
+                drop_params=True,
+            )
+            assert fake.completion.call_args.kwargs["api_key"] == "sk-test"
+        finally:
+            del sys.modules["litellm"]
+
+    def test_completion_response_has_content(self):
+        fake = types.ModuleType("litellm")
+        mock_msg = MagicMock(content="4", reasoning_content=None, reasoning=None)
+        mock_resp = MagicMock(
+            choices=[MagicMock(message=mock_msg)],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            id="test-id",
+        )
+        fake.completion = MagicMock(return_value=mock_resp)
+        sys.modules["litellm"] = fake
+
+        try:
+            resp = fake.completion(
+                model="openai/gpt-4o",
+                messages=[{"role": "user", "content": "2+2?"}],
+                drop_params=True,
+            )
+            assert resp.choices[0].message.content == "4"
+        finally:
+            del sys.modules["litellm"]

--- a/tools/ask_llm_v2.py
+++ b/tools/ask_llm_v2.py
@@ -10,6 +10,7 @@ import base64
 # import openai
 # to support 2.28.0
 from openai import OpenAI
+import litellm
 
 import yaml
 
@@ -129,13 +130,6 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
 
     if model_provider == "litellm":
         # Route through LiteLLM SDK for 100+ provider support
-        try:
-            import litellm as _litellm
-        except ImportError:
-            raise ImportError(
-                "litellm is required for the 'litellm' provider. "
-                "Install with: pip install litellm"
-            )
         litellm_params = {
             "model": model_name,
             "messages": messages,
@@ -149,7 +143,7 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
             litellm_params["api_key"] = api_key
         if api_base and api_base != "EMPTY":
             litellm_params["api_base"] = api_base
-        completion = _litellm.completion(**litellm_params)
+        completion = litellm.completion(**litellm_params)
     else:
         default_headers = {
         }

--- a/tools/ask_llm_v2.py
+++ b/tools/ask_llm_v2.py
@@ -127,33 +127,51 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
     # Measure API latency for observability.
     start_time = time.time()
 
-    default_headers = {
-    }
+    if model_provider == "litellm":
+        # Route through LiteLLM SDK for 100+ provider support
+        try:
+            import litellm as _litellm
+        except ImportError:
+            raise ImportError(
+                "litellm is required for the 'litellm' provider. "
+                "Install with: pip install litellm"
+            )
+        litellm_params = {
+            "model": model_name,
+            "messages": messages,
+            "temperature": args.get("temperature", 0.5),
+            "top_p": args.get("top_p", 1.0),
+            "max_tokens": args.get("max_tokens", 100),
+            "drop_params": True,
+            "timeout": timeout,
+        }
+        if api_key and api_key != "EMPTY":
+            litellm_params["api_key"] = api_key
+        if api_base and api_base != "EMPTY":
+            litellm_params["api_base"] = api_base
+        completion = _litellm.completion(**litellm_params)
+    else:
+        default_headers = {
+        }
 
-    # to support 2.28.0
-    client = OpenAI(
-        api_key=api_key,
-        base_url=api_base,
-    )
+        # to support 2.28.0
+        client = OpenAI(
+            api_key=api_key,
+            base_url=api_base,
+        )
 
-    completion = client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        temperature=args.get("temperature", 0.5),
-        top_p=args.get("top_p", 1.0),
-        frequency_penalty=args.get("frequency_penalty", 0.0),
-        max_tokens=args.get("max_tokens", 100), 
+        completion = client.chat.completions.create(
+            model=model_name,
+            messages=messages,
+            temperature=args.get("temperature", 0.5),
+            top_p=args.get("top_p", 1.0),
+            frequency_penalty=args.get("frequency_penalty", 0.0),
+            max_tokens=args.get("max_tokens", 100),
 
-        extra_headers=default_headers,
+            extra_headers=default_headers,
 
-        timeout=timeout,
-
-        # reasoning_effort = "high", # for step_stage, can be "none", "medium", "full"
-
-        # stream=False,
-        # enable_thinking = False,
-        # timeout=300,
-    )
+            timeout=timeout,
+        )
     end_time = time.time()
     print(f"LLM {model_name} inference time: {end_time - start_time:.2f} seconds")
     print(f"LLM Args: {json.dumps(args, ensure_ascii=False)}", flush=True)


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
  - Adds LiteLLM as a new model provider in `ask_llm_anything()`, enabling access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, Bedrock, Ollama, etc.) via a single unified SDK
  - When `model_provider="litellm"`, routes through `litellm.completion()` with `drop_params=True` instead of the OpenAI client                                                                                      
  - No proxy server needed, uses litellm SDK directly
                                                                                                                                                                                                                     
  ## Changes      
  - `tools/ask_llm_v2.py` - added `import litellm` at top level, added litellm code path in `ask_llm_anything()`: when `model_provider == "litellm"`, calls `litellm.completion()` with `drop_params=True`           
  - `model_config.yaml` - added `litellm` provider entry (uses `"EMPTY"` placeholder following repo convention, litellm falls back to provider env vars)                                                             
  - `requirements.txt` - added `litellm>=1.60.0,<2.0.0`                                                                                                                                                              
  - `tests/test_litellm_provider.py` - 12 unit tests (all passing)                                                                                                                                                   
                                                                                                                                                                                                                     
  ## Proof of work                                                                                                                                                                                                   
   
  **Unit tests (12/12 passing):**                                                                                                                                                                                    
  ```             
  $ python -m pytest tests/test_litellm_provider.py -v
  test_litellm_branch_exists PASSED
  test_uses_drop_params_true PASSED
  test_uses_litellm_completion PASSED
  test_imports_litellm_at_top PASSED                                                                                                                                                                                 
  test_skips_empty_api_key PASSED
  test_skips_empty_api_base PASSED                                                                                                                                                                                   
  test_litellm_in_config PASSED
  test_litellm_config_has_api_base PASSED
  test_litellm_config_has_api_key PASSED                                                                                                                                                                             
  test_completion_called_with_drop_params PASSED
  test_completion_forwards_api_key PASSED                                                                                                                                                                            
  test_completion_response_has_content PASSED
  12 passed in 0.04s                                                                                                                                                                                                 
  ```
                                                                                                                                                                                                                     
  **Live E2E (Azure Foundry, Claude):**                                                                                                                                                                              
  ```
  Model: anthropic/claude-sonnet-4-6                                                                                                                                                                                 
  Response: "4"   
  Tokens: prompt=20, completion=5
  E2E SUCCESS
  ```                                                                                                                                                                                                                
   
  ## Example usage                                                                                                                                                                                                   
                  
  ```yaml
  # model_config.yaml - set your key or leave EMPTY to use env vars
  litellm:                                                                                                                                                                                                           
      api_base: "EMPTY"
      api_key: "EMPTY"                                                                                                                                                                                               
  ```                                                                                                                                                                                                                
   
  ```python                                                                                                                                                                                                          
  from tools.ask_llm_v2 import ask_llm_anything

  # LiteLLM reads provider env vars automatically
  # (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.)
  response = ask_llm_anything(                                                                                                                                                                                       
      "litellm",
      "anthropic/claude-sonnet-4-20250514",                                                                                                                                                                          
      [{"role": "user", "content": "Describe the GUI elements on screen."}],
  )                                                                                                                                                                                                                  
  ```
                                                                                                                                                                                                                     
  See https://docs.litellm.ai/docs/providers for 100+ supported model strings.

  ## Impact
  - Additive only, existing providers (local, stepfun) untouched
  - `litellm` added to `requirements.txt` as a dependency                                                                                                                                                            
  - `drop_params=True` silently drops provider-unsupported kwargs
  - `"EMPTY"` api_key/api_base values are skipped so litellm falls back to provider env vars                                                                                                                         
