### PR TITLE
feat(evaluate): add Pass@N retry scheduler with VLM Judge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 config.yaml
 */*.pyc
+**/__pycache__/
 tmp_screenshot
 output/
 running_log

--- a/copilot_agent_client/pu_client.py
+++ b/copilot_agent_client/pu_client.py
@@ -127,6 +127,11 @@ def evaluate_task_on_device(agent_server, device_info, task, rollout_config, ext
     delay_after_capture = rollout_config.get('delay_after_capture', 2)
 
     history_actions = []
+    # 保留执行期截图的 base64，供 Judge 使用
+    # 只保留最后 JUDGE_SCREENSHOT_KEEP 张，避免内存占用过大
+    # key = step_idx（0-based），value = base64 url
+    JUDGE_SCREENSHOT_KEEP = 5
+    step_screenshots: dict[int, str] = {}
 
     for step_idx in range(max_steps):
 
@@ -138,6 +143,13 @@ def evaluate_task_on_device(agent_server, device_info, task, rollout_config, ext
 
         image_b64_url = make_b64_url(image_path, resize_config=rollout_config['model_config'].get("resize_config", None))
         smart_remove(image_path)
+
+        # 分叉：同一张截图保存一份给 Judge，不影响 Agent 处理路径
+        step_screenshots[step_idx] = image_b64_url
+        # 只保留最后 K 步，滚动丢弃更早的
+        if len(step_screenshots) > JUDGE_SCREENSHOT_KEEP:
+            oldest_key = min(step_screenshots)
+            del step_screenshots[oldest_key]
         
         payload = {
             "session_id": session_id,
@@ -196,8 +208,21 @@ def evaluate_task_on_device(agent_server, device_info, task, rollout_config, ext
 
     # return_log['session_id'] = session_id
     return_log['stop_reason'] = stop_reason
-
     return_log['stop_steps'] = step_idx + 1
+    # judge 需要的字段：最终动作返回文本 + 完整历史
+    # 注意：COMPLETE 的消息字段名是 'return'（协议格式：action:COMPLETE\treturn:...）
+    #       ABORT   的消息字段名是 'value' （协议格式：action:ABORT\tvalue:...）
+    if stop_reason == 'COMPLETE':
+        return_log['return_val'] = action.get('return') or action.get('value') or ''
+    elif stop_reason == 'ABORT':
+        return_log['return_val'] = action.get('value') or action.get('return') or ''
+    else:
+        return_log['return_val'] = ''
+    return_log['history_actions'] = history_actions
+    # 执行期截图（最后 JUDGE_SCREENSHOT_KEEP 步），Judge 直接用这些，不再延迟补截
+    # last_step_screenshot：COMPLETE/ABORT 那一步 Agent 实际看到的画面，最高优先级
+    return_log['step_screenshots'] = step_screenshots
+    return_log['last_step_screenshot'] = step_screenshots.get(step_idx)
 
     print(f"Task {task} done in {len(history_actions)} steps. Session ID: {session_id}")
 

--- a/evaluate/judge.py
+++ b/evaluate/judge.py
@@ -1,0 +1,498 @@
+"""
+judge.py — VLM Judge for gelab-zero task evaluation.
+
+分级判定策略（按 judge_mode）：
+  - "auto"      : 根据 stop_reason 和截图是否存在自动选择 skip / text / vlm
+  - "vlm"       : 强制走全量 VLM（截图 + 历史）
+  - "text"      : 强制纯文本判定（无截图，只看历史和 return_val）
+  - "skip"      : 跳过 Judge，直接以 stop_reason 兜底
+
+auto 模式决策表：
+  ABORT                          → 直接 fail，0 次 LLM
+  return_val 含失败关键词         → 直接 fail，0 次 LLM
+  COMPLETE + 有截图               → vlm（全量，最深度）
+  COMPLETE + 无截图               → text（降级）
+  MAX_STEPS_REACHED + 有截图     → vlm（可能跑完了但没 COMPLETE）
+  MAX_STEPS_REACHED + 无截图     → skip（直接判 fail，省 LLM 调用）
+"""
+
+import json
+import logging
+import re
+from typing import Literal
+
+from tools.ask_llm_v2 import ask_llm_anything
+
+logger = logging.getLogger("evaluate.judge")
+
+# ---------------------------------------------------------------------------
+# 常量
+# ---------------------------------------------------------------------------
+
+# 快速过滤：含以下词的 return_val 直接判 fail，节省 LLM 调用
+_FAILURE_KEYWORDS = [
+    "无法完成", "失败", "不能", "错误", "超时", "未完成",
+    "cannot", "failed", "failure", "unable", "error", "timeout",
+]
+
+# Judge provider key（对应 model_config.yaml 中的节名）
+# 只暴露 provider，model_name 从配置文件读取，不在代码中硬编码
+DEFAULT_JUDGE_PROVIDER = "judge"
+
+
+def get_judge_model_name(provider: str = DEFAULT_JUDGE_PROVIDER) -> str:
+    """
+    从 model_config.yaml 读取 judge 模型名。
+
+    设计意图：model_name 集中维护在配置文件，不在代码里硬编码。
+    要切换 judge 模型（如从 StepFun 换成 Claude / Qwen / 本地模型），
+    只需修改 model_config.yaml 中对应 provider 节的 model_name，代码无需改动。
+
+    Args:
+        provider: model_config.yaml 中的 provider key，默认 "judge"
+
+    Returns:
+        模型名字符串；配置缺失时抛出 ValueError
+
+    Raises:
+        ValueError: provider 不存在或未配置 model_name
+    """
+    import yaml
+
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    if provider not in config:
+        raise ValueError(
+            f"Judge provider '{provider}' not found in model_config.yaml. "
+            f"Available providers: {list(config.keys())}"
+        )
+
+    provider_cfg = config[provider]
+    model_name = provider_cfg.get("model_name", "")
+    if not model_name:
+        raise ValueError(
+            f"model_config.yaml [{provider}] is missing 'model_name'. "
+            f"Add 'model_name: your-model-name' under the [{provider}] section."
+        )
+
+    return model_name
+
+_JUDGE_SYSTEM_PROMPT = """你是一个专业的移动端 AI Agent 测试评估员。
+
+## 核心判定原则
+**截图是判定 pass/fail 的最高优先级依据。此截图是 Agent 做出 COMPLETE 决策时实际看到的画面。**
+
+判定规则（按优先级）：
+1. **截图与 Agent 返回值交叉核验**：若任务要求提取屏幕内容（如"第一名是什么"、"告诉我XXX"），必须对比截图中实际显示的内容与 Agent 的返回值是否一致。**返回值与截图不符 → fail**，即使截图页面正确。
+2. 截图清楚显示任务目标状态（目标页面已打开/操作已完成/内容已展示）且与返回值一致 → **pass**，不论过程是否低效
+3. 截图明确显示任务未完成（停在错误页/目标未出现）→ **fail**
+4. 无截图时：综合 verify/note/key_process 字段判断，更严格
+
+## 执行历史字段说明
+执行历史中的每一步除动作类型外，还包含 Agent 自身的认知记录：
+- **verify结论**：Agent 对上一步动作是否生效的自我评估，"符合预期"表示该步成功
+- **note**：Agent 对当前截图的关键信息提取，包含 UI 状态、文字内容、控件状态
+- **key_process**：Agent 认为已完成的关键进展里程碑
+
+note 字段记录了 Agent 对每步截图的语义理解，可用于发现 Agent 读图幻觉（note 描述与截图实际内容不符的情况）。
+
+**过程质量（process_score）与任务完成（verdict）是两个独立维度，互不影响。**
+
+## 输出格式（严格 JSON，不输出任何其他内容）
+{
+  "verdict": "pass 或 fail",
+  "confidence": 0.0到1.0,
+  "reason": "一句话，30字以内，聚焦最终状态或不一致原因",
+  "process_score": 0.0到1.0,
+  "process_comment": "执行过程简评（效率/决策合理性/verify符合率/冗余步骤）",
+  "analysis": {
+    "failure_summary": "失败原因概述，pass时填null",
+    "root_cause": "UI变更/网络超时/登录异常/元素定位失败/任务理解偏差/读图幻觉/返回值与截图不符/其他",
+    "suggestions": ["改进建议1", "改进建议2"]
+  }
+}"""
+
+_JUDGE_USER_TEMPLATE = """## 任务描述
+{task}
+
+## 执行历史（最后 {history_len} 步）
+{history_summary}
+
+## Agent 最终状态
+- stop_reason: {stop_reason}
+- return_val: {return_val}
+
+{screenshot_section}请对本次执行进行评估。"""
+
+
+# ---------------------------------------------------------------------------
+# 内部工具函数
+# ---------------------------------------------------------------------------
+
+def _build_history_summary(history_actions: list[dict], max_steps: int = 25) -> tuple[str, int]:
+    """
+    从 history_actions 提取结构化摘要供 Judge 使用。
+
+    除了动作类型和坐标，还提取 Agent 自身的认知字段：
+      - note:        Agent 对当前截图的关键信息提取（文字/控件状态/进度）
+      - verify:      Agent 对上一步动作是否生效的自我评估
+      - key_process: Agent 认为当前完成了哪些关键进展
+
+    这三个字段来自 parser 的输出格式，是 Agent 在执行时对每张截图的
+    语义理解，Judge 结合这些信息可以做更深度的判断，而不只是看最终截图。
+
+    Returns:
+        (summary_text, actual_steps_shown)
+    """
+    if not history_actions:
+        return "(无历史数据)", 0
+
+    tail = history_actions[-max_steps:]
+    lines = []
+    if len(history_actions) > max_steps:
+        lines.append(f"...(前 {len(history_actions) - max_steps} 步已省略)...")
+
+    offset = len(history_actions) - len(tail)
+    for i, action in enumerate(tail, start=offset + 1):
+        action_type = action.get("action_type", "UNKNOWN")
+        value = action.get("value", "")
+        # 截断过长的 value（避免带入截图 base64 等大字段）
+        if isinstance(value, str) and len(value) > 150:
+            value = value[:150] + "...[truncated]"
+        coordinate = action.get("coordinate", "")
+        coord_str = f"  coord={coordinate}" if coordinate else ""
+
+        lines.append(f"Step {i}: [{action_type}]{coord_str}  value={value!r}")
+
+        # Agent 对本步截图的语义理解：verify / note / key_process
+        # 这些字段来自 parser 输出，代表 Agent 自己对 UI 状态的判断
+        verify = action.get("verify", "").strip()
+        note = action.get("note", "").strip()
+        key_process = action.get("key_process", "").strip()
+
+        if verify and verify.lower() not in ("", "none"):
+            # 只保留 verify 结论句，去掉冗长描述（节省 token）
+            # 格式约定："因此我判断（符合｜不符合）上一步预期"
+            if "因此我判断" in verify:
+                verdict_line = verify[verify.rfind("因此我判断"):]
+                lines.append(f"  ↳ verify结论: {verdict_line[:80]}")
+            else:
+                lines.append(f"  ↳ verify: {verify[:80]}")
+
+        if note and note.lower() not in ("", "none"):
+            # note 可能很长（要求记录全文），截断到合理长度
+            note_preview = note[:200] + "..." if len(note) > 200 else note
+            lines.append(f"  ↳ note: {note_preview}")
+
+        if key_process and key_process.lower() not in ("", "none"):
+            lines.append(f"  ↳ key_process: {key_process[:120]}")
+
+    return "\n".join(lines), len(tail)
+
+
+def _check_scroll_requirement(
+    history_actions: list[dict],
+    judge_criteria: str,
+) -> dict | None:
+    """
+    若 judge_criteria 要求阅读全文，检查 history_actions 中是否有滑动操作。
+    有滑动 → 返回 None（继续走 VLM Judge）。
+    无滑动 → 直接返回 fail，不调 LLM。
+    """
+    READ_KEYWORDS = ["阅读全文", "滑动到底", "滑动到文章底部", "读完全文", "全文"]
+    needs_scroll = any(kw in judge_criteria for kw in READ_KEYWORDS)
+    if not needs_scroll:
+        return None
+
+    has_scroll = any(
+        str(a.get("action_type", "")).upper() in ("SLIDE", "SCROLL")
+        for a in history_actions
+    )
+    if has_scroll:
+        return None
+
+    return _make_result(
+        passed=False,
+        verdict="fail",
+        confidence=0.95,
+        reason="任务要求阅读全文但 Agent 全程未滑动页面",
+        process_score=0.1,
+        process_comment="未执行任何滑动操作即 COMPLETE，未完成全文阅读",
+        root_cause="missing_scroll",
+        suggestions=["在 COMPLETE 前应多次 SLIDE 滑动文章页直到底部"],
+    )
+
+
+def _quick_check(return_val: str, stop_reason: str) -> dict | None:
+    """
+    快速判定：不需要 LLM 调用就能确定结果的情况。
+
+    Returns:
+        判定结果 dict，或 None（表示需要继续走 LLM Judge）。
+    """
+    # ABORT：Agent 主动放弃，直接 fail
+    if stop_reason.upper() == "ABORT":
+        return _make_result(
+            passed=False,
+            verdict="fail",
+            confidence=1.0,
+            reason="Agent 主动 ABORT",
+            process_score=0.3,
+            process_comment="Agent 诚实放弃",
+            root_cause="agent_abort",
+        )
+
+    # return_val 含失败关键词
+    if return_val:
+        for kw in _FAILURE_KEYWORDS:
+            if kw.lower() in return_val.lower():
+                return _make_result(
+                    passed=False,
+                    verdict="fail",
+                    confidence=0.9,
+                    reason=f"Agent 返回含失败关键词「{kw}」",
+                    process_score=0.0,
+                    process_comment="",
+                    root_cause="agent_reported_failure",
+                )
+
+    return None
+
+
+def _make_result(
+    *,
+    passed: bool | None,
+    verdict: str,
+    confidence: float,
+    reason: str,
+    process_score: float,
+    process_comment: str,
+    root_cause: str = "",
+    suggestions: list[str] | None = None,
+) -> dict:
+    """统一构造 judge 结果 dict。"""
+    return {
+        "pass": passed,
+        "verdict": verdict,
+        "confidence": confidence,
+        "reason": reason,
+        "process_score": process_score,
+        "process_comment": process_comment,
+        "analysis": {
+            "failure_summary": None if passed else reason,
+            "root_cause": root_cause,
+            "suggestions": suggestions or [],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 核心 Judge 函数
+# ---------------------------------------------------------------------------
+
+def run_judge(
+    task: str,
+    return_val: str,
+    stop_reason: str,
+    history_actions: list[dict],
+    final_screenshot_b64: str | None = None,
+    judge_mode: Literal["auto", "vlm", "text", "skip"] = "auto",
+    judge_criteria: str = "",
+    judge_model_provider: str = DEFAULT_JUDGE_PROVIDER,
+    judge_model_name: str | None = None,
+) -> dict:
+    """
+    运行 VLM Judge，返回判断结果。
+
+    judge_criteria: 额外验收标准，追加到 prompt 中让 Judge 额外考量。
+    例如："需要滑动到文章底部，截图应能看到文章末尾或评论区入口"
+
+    Args:
+        task: 任务描述字符串
+        return_val: Agent COMPLETE/ABORT 时的 value 文本
+        stop_reason: COMPLETE / ABORT / MAX_STEPS_REACHED / MANUAL_STOP
+        history_actions: evaluate_task_on_device 返回的 history_actions 列表
+        final_screenshot_b64: 延迟截取的最终截图，格式为 data:image/jpeg;base64,...
+                              为 None 时不做视觉判断
+        judge_mode: 判定策略，"auto" 时根据 stop_reason + 截图自动选择
+        judge_model_provider: model_config.yaml 中的 provider key
+        judge_model_name: judge 使用的模型名
+
+    Returns:
+        {
+            "pass": bool | None,      # None 表示 judge 跳过
+            "verdict": str,           # "pass" / "fail" / "skip" / "error"
+            "confidence": float,
+            "reason": str,
+            "process_score": float,   # 0~1，独立于 verdict
+            "process_comment": str,
+            "analysis": {
+                "failure_summary": str | None,
+                "root_cause": str,
+                "suggestions": list[str],
+            },
+        }
+    """
+    # ---- 第一层：快速判定（0 次 LLM）----
+    quick = _quick_check(return_val, stop_reason)
+    if quick is not None:
+        logger.info(f"[Judge] 快速判定: {quick['verdict']}  reason={quick['reason']}")
+        return quick
+
+    # ---- 第一层补充：滑动行为检查（0 次 LLM）----
+    scroll_check = _check_scroll_requirement(history_actions, judge_criteria)
+    if scroll_check is not None:
+        logger.info(f"[Judge] 滑动检查未通过: {scroll_check['reason']}")
+        return scroll_check
+
+    # ---- 解析 judge model name（None 时从 model_config.yaml 读取）----
+    if judge_model_name is None:
+        judge_model_name = get_judge_model_name(judge_model_provider)
+    logger.info(f"[Judge] provider={judge_model_provider}  model={judge_model_name}")
+
+    # ---- 确定实际执行模式 ----
+    has_screenshot = bool(final_screenshot_b64)
+
+    if judge_mode == "skip":
+        effective_mode = "skip"
+    elif judge_mode == "vlm":
+        effective_mode = "vlm"
+    elif judge_mode == "text":
+        effective_mode = "text"
+    else:
+        # auto：根据 stop_reason 和截图决定
+        if has_screenshot:
+            # 有截图时都走 vlm，充分利用 StepFun 的 GUI 理解能力
+            effective_mode = "vlm"
+        else:
+            # 无截图：COMPLETE 降级到 text，MAX_STEPS 直接 skip（大概率失败）
+            if stop_reason.upper() == "COMPLETE":
+                effective_mode = "text"
+            else:
+                effective_mode = "skip"
+
+    logger.info(
+        f"[Judge] mode={judge_mode} → effective={effective_mode}  "
+        f"stop={stop_reason}  has_screenshot={has_screenshot}"
+    )
+
+    # ---- skip 模式：以 stop_reason 兜底 ----
+    if effective_mode == "skip":
+        passed = stop_reason.upper() == "COMPLETE"
+        return _make_result(
+            passed=passed,
+            verdict="pass" if passed else "fail",
+            confidence=0.5,
+            reason=f"Judge 跳过，以 stop_reason={stop_reason} 兜底",
+            process_score=0.5,
+            process_comment="",
+            root_cause="judge_skipped",
+        )
+
+    # ---- 构建 LLM 请求 ----
+    history_summary, history_len = _build_history_summary(history_actions)
+
+    # 额外验收标准：追加到 screenshot_section 之后
+    criteria_section = f"## 额外验收标准\n{judge_criteria}\n\n" if judge_criteria.strip() else ""
+
+    if effective_mode == "vlm" and has_screenshot:
+        screenshot_section = "## 最终截图\n（已附带，请结合截图判断）\n\n" + criteria_section
+        user_text = _JUDGE_USER_TEMPLATE.format(
+            task=task,
+            history_len=history_len,
+            history_summary=history_summary,
+            stop_reason=stop_reason,
+            return_val=return_val or "(Agent 未返回任何文本)",
+            screenshot_section=screenshot_section,
+        )
+        messages = [
+            {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": user_text},
+                    {"type": "image_url", "image_url": {"url": final_screenshot_b64}},
+                ],
+            },
+        ]
+    else:
+        # text 模式：无截图
+        screenshot_section = "## 最终截图\n（无截图，请仅依据执行历史和返回值判断，不得因缺少截图判定失败）\n\n" + criteria_section
+        user_text = _JUDGE_USER_TEMPLATE.format(
+            task=task,
+            history_len=history_len,
+            history_summary=history_summary,
+            stop_reason=stop_reason,
+            return_val=return_val or "(Agent 未返回任何文本)",
+            screenshot_section=screenshot_section,
+        )
+        messages = [
+            {"role": "system", "content": _JUDGE_SYSTEM_PROMPT},
+            {"role": "user", "content": user_text},
+        ]
+
+    # ---- 调用 LLM（最多重试 2 次，应对空响应或 JSON 解析失败）----
+    last_exc: Exception | None = None
+    for _attempt in range(3):
+        try:
+            raw = ask_llm_anything(
+                model_provider=judge_model_provider,
+                model_name=judge_model_name,
+                messages=messages,
+                args={
+                    "max_tokens": 1024,
+                    "temperature": 0.0,
+                    "top_p": 1.0,
+                    "frequency_penalty": 0.0,
+                },
+            )
+            # 去掉 <think>...</think> 推理段落
+            if "</think>" in raw:
+                raw = raw.split("</think>")[-1].strip()
+
+            if not raw.strip():
+                raise ValueError("Judge LLM 返回了空内容（仅有 think 段落，正文为空）")
+
+            json_match = re.search(r"\{.*\}", raw, re.DOTALL)
+            if not json_match:
+                raise ValueError(f"Judge LLM 返回内容中未找到 JSON：{raw[:200]!r}")
+            parsed = json.loads(json_match.group())
+
+            verdict = str(parsed.get("verdict", "fail")).lower()
+            analysis = parsed.get("analysis") or {}
+            result = {
+                "pass": verdict == "pass",
+                "verdict": verdict,
+                "confidence": float(parsed.get("confidence", 0.5)),
+                "reason": parsed.get("reason", ""),
+                "process_score": float(parsed.get("process_score", 0.5)),
+                "process_comment": parsed.get("process_comment", ""),
+                "analysis": {
+                    "failure_summary": analysis.get("failure_summary"),
+                    "root_cause": analysis.get("root_cause", ""),
+                    "suggestions": analysis.get("suggestions") or [],
+                },
+            }
+            logger.info(
+                f"[Judge] verdict={result['verdict']}  "
+                f"confidence={result['confidence']:.2f}  "
+                f"reason={result['reason']}"
+            )
+            return result
+
+        except Exception as e:
+            last_exc = e
+            logger.warning(f"[Judge] 第 {_attempt + 1} 次调用失败: {e}，{'重试中...' if _attempt < 2 else '已达最大重试次数'}")
+
+    # 所有重试均失败
+    logger.error(f"[Judge] LLM 调用全部失败: {last_exc}", exc_info=True)
+    return _make_result(
+        passed=None,
+        verdict="error",
+        confidence=0.0,
+        reason=f"Judge 调用异常: {last_exc}",
+        process_score=0.0,
+        process_comment="",
+        root_cause="judge_error",
+    )

--- a/evaluate/runner.py
+++ b/evaluate/runner.py
@@ -1,0 +1,278 @@
+"""
+runner.py — Pass@N retry wrapper with VLM Judge for gelab-zero.
+
+使用方式：
+    from evaluate.runner import run_task_pass_at_n
+
+    result = run_task_pass_at_n(
+        agent_server=l2_server,
+        device_info=device_info,
+        task="打开微信给柏茗发 helloworld",
+        rollout_config=local_model_config,
+    )
+    print(result['success'], result['attempts'])
+    print(result['judge']['verdict'], result['judge']['reason'])
+
+Pass@N 行为：
+  - Agent 完成 → 立即跑 Judge（inline 判断）
+    - Judge=pass  → 成功，退出循环
+    - Judge=fail  → 还有机会则继续重试，否则判失败
+  - Agent 失败（ABORT / MAX_STEPS）→ 无论是否还有机会，快速 Judge 后决定是否重试
+"""
+
+import logging
+import time
+from typing import Literal
+
+from copilot_agent_client.pu_client import evaluate_task_on_device
+from copilot_front_end.mobile_action_helper import (
+    capture_screenshot,
+    open_screen,
+    press_home_key,
+)
+from tools.image_tools import make_b64_url
+from megfile import smart_remove
+
+from evaluate.judge import (
+    DEFAULT_JUDGE_PROVIDER,
+    run_judge,
+)
+
+logger = logging.getLogger("evaluate.runner")
+
+# Agent 完成后等待页面稳定再截图（秒）
+_JUDGE_DELAY_SECONDS = 5
+
+
+# ---------------------------------------------------------------------------
+# 内部工具
+# ---------------------------------------------------------------------------
+
+
+def _reset_device_env(device_id: str) -> None:
+    """每次 attempt 前将设备回到主屏幕，保证干净起点。"""
+    try:
+        open_screen(device_id)
+        press_home_key(device_id)
+        logger.info(f"[Reset] 设备 {device_id} 已回到主屏幕")
+    except Exception as e:
+        logger.warning(f"[Reset] 设备重置失败（继续执行）: {e}")
+
+
+def _take_judge_screenshot(
+    device_id: str,
+    delay_seconds: int = _JUDGE_DELAY_SECONDS,
+) -> str | None:
+    """
+    等待页面稳定后截取最终状态截图。
+
+    Args:
+        device_id: ADB 设备 ID
+        delay_seconds: 等待秒数，让页面从过渡态稳定下来
+
+    Returns:
+        data:image/jpeg;base64,... 格式的 URL；失败时返回 None
+    """
+    logger.info(f"[Screenshot] 等待 {delay_seconds}s 让页面稳定...")
+    time.sleep(delay_seconds)
+    try:
+        tmp_path = capture_screenshot(device_id, "judge_screenshot_tmp", print_command=False)
+        b64_url = make_b64_url(tmp_path)
+        smart_remove(tmp_path)
+        logger.info("[Screenshot] 稳定态截图已获取")
+        return b64_url
+    except Exception as e:
+        logger.warning(f"[Screenshot] 截图失败: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# 核心入口
+# ---------------------------------------------------------------------------
+
+
+def run_task_pass_at_n(
+    agent_server,
+    device_info: dict,
+    task: str,
+    rollout_config: dict,
+    pass_count: int = 3,
+    judge_model_provider: str = DEFAULT_JUDGE_PROVIDER,
+    judge_model_name: str | None = None,
+    judge_mode: Literal["auto", "vlm", "text", "skip"] = "auto",
+    judge_criteria: str = "",
+    extra_info: dict | None = None,
+) -> dict:
+    """
+    带 Pass@N 重试和 VLM Judge 的任务执行器。
+
+    judge_model_name 默认为 None，自动从 model_config.yaml [judge] 节读取。
+    要切换 judge 模型：修改 model_config.yaml 中 judge.model_name 即可，无需改代码。
+    临时覆盖（测试用）：直接传入 judge_model_name="other-model-name"。
+
+    judge_criteria: 额外的验收标准，Judge 会在判定时额外考量。
+    例如："需要滑动到文章底部阅读全文，截图中应能看到文章末尾或评论区"
+
+    Args:
+        agent_server: LocalServer 实例
+        device_info: {"device_id": str, "device_wm_size": tuple}
+        task: 任务描述
+        rollout_config: 模型和执行配置（与原始 evaluate_task_on_device 格式一致）
+        pass_count: 最多尝试 N 次，默认 3
+        judge_model_provider: model_config.yaml 中 judge 的 provider key
+        judge_model_name: judge 模型名
+        judge_mode: "auto"（推荐）/ "vlm"（强制视觉）/ "text"（强制纯文本）/ "skip"（关闭 judge）
+        extra_info: 透传给 evaluate_task_on_device 的额外信息
+
+    Returns:
+        {
+            "success": bool,
+            "attempts": int,           # 实际执行次数
+            "stop_reason": str,        # 最后一次的 stop_reason
+            "return_val": str,         # Agent COMPLETE 时的返回文本
+            "judge": dict | None,      # 最后一次 VLM Judge 结果
+            "all_attempts": list[dict] # 每次 attempt 的详情（含各自 judge 结果）
+        }
+    """
+    device_id = device_info["device_id"]
+    pass_count = max(1, pass_count)
+    extra_info = extra_info or {}
+
+    # 自动检测 task 是否属于"阅读全文"场景，若是则注入滑动 criteria 和 task 提示
+    # 只在调用方没有传入 judge_criteria 时才自动推断，传入了就尊重调用方的设置
+    _READ_TASK_KEYWORDS = ["阅读全文", "总结全文", "读完", "查看全文",
+                           "公众号", "推文", "文章", "新闻", "博客", "帖子"]
+    _READ_CRITERIA = (
+        "如果任务涉及阅读文章/推文，必须多次 SLIDE 滑动到文章底部阅读全文，"
+        "截图中应能看到文章末尾内容或评论区入口，否则判定为 fail。"
+    )
+    _READ_HINT = "【重要】进入文章页后，必须多次向上滑动（SLIDE）直到页面底部，看到评论区或文末标识后再总结全文内容。"
+
+    if not judge_criteria:
+        if any(kw in task for kw in _READ_TASK_KEYWORDS):
+            judge_criteria = _READ_CRITERIA
+            if _READ_HINT not in task:
+                task = task + "\n" + _READ_HINT
+            logger.info("[Runner] 检测到全文阅读场景，已自动注入滑动 criteria 和 task 提示")
+    else:
+        # 调用方显式传入了 criteria，沿用旧逻辑：若 criteria 含阅读全文关键词则追加 task 提示
+        _READ_KEYWORDS = ["阅读全文", "滑动到底", "读完全文", "全文"]
+        if any(kw in judge_criteria for kw in _READ_KEYWORDS):
+            if _READ_HINT not in task:
+                task = task + "\n" + _READ_HINT
+                logger.info("[Runner] judge_criteria 含全文阅读要求，已自动追加滑动提示到 task")
+
+    all_attempts: list[dict] = []
+    final_judge: dict | None = None
+    success = False
+    last_stop_reason = "UNKNOWN"
+    last_return_val = ""
+
+    for attempt in range(1, pass_count + 1):
+        sep = "=" * 50
+        logger.info(sep)
+        logger.info(f"Attempt {attempt}/{pass_count}  task={task!r}")
+        logger.info(sep)
+
+        # 每次 attempt 前重置环境
+        _reset_device_env(device_id)
+
+        # ---- 执行 Agent ----
+        attempt_result: dict = {}
+        try:
+            attempt_result = evaluate_task_on_device(
+                agent_server=agent_server,
+                device_info=device_info,
+                task=task,
+                rollout_config=rollout_config,
+                extra_info=extra_info,
+                reflush_app=True,
+                reset_environment=False,  # 已在上方手动重置
+            )
+        except Exception as e:
+            logger.error(f"Attempt {attempt} 执行异常: {e}", exc_info=True)
+            attempt_record = {"attempt": attempt, "error": str(e), "judge": None}
+            all_attempts.append(attempt_record)
+            if attempt < pass_count:
+                logger.info("将在下一次 attempt 重试...")
+                continue
+            break
+
+        stop_reason = attempt_result.get("stop_reason", "UNKNOWN")
+        return_val = attempt_result.get("return_val", "")
+        history_actions = attempt_result.get("history_actions", [])
+        last_stop_reason = stop_reason
+        last_return_val = return_val
+
+        logger.info(f"Attempt {attempt}: stop_reason={stop_reason}  return_val={return_val!r}")
+
+        # ---- 截图策略：优先用执行期 last_step_screenshot，去掉延迟补截 ----
+        # last_step_screenshot 是 Agent 做出 COMPLETE/ABORT 决策时实际看到的那张图
+        # 比延迟 5 秒补截更可信：设备状态尚未因 Agent 操作后的副作用改变
+        final_screenshot_b64: str | None = None
+        if stop_reason.upper() not in ("ABORT",):
+            final_screenshot_b64 = attempt_result.get("last_step_screenshot")
+            if final_screenshot_b64:
+                logger.info("[Judge] 使用执行期 last_step_screenshot（COMPLETE 时 Agent 实际看到的画面）")
+            else:
+                logger.warning("[Judge] last_step_screenshot 不可用，降级到延迟截图")
+                final_screenshot_b64 = _take_judge_screenshot(device_id)
+
+        # ---- 运行 VLM Judge ----
+        logger.info(f"[Judge] 运行 Judge（attempt {attempt}/{pass_count})...")
+        judge_result = run_judge(
+            task=task,
+            return_val=return_val,
+            stop_reason=stop_reason,
+            history_actions=history_actions,
+            final_screenshot_b64=final_screenshot_b64,
+            judge_mode=judge_mode,
+            judge_criteria=judge_criteria,
+            judge_model_provider=judge_model_provider,
+            judge_model_name=judge_model_name,
+        )
+        final_judge = judge_result
+
+        judge_pass = judge_result.get("pass")
+        logger.info(
+            f"[Judge] verdict={judge_result['verdict']}  "
+            f"confidence={judge_result['confidence']:.2f}  "
+            f"reason={judge_result['reason']}"
+        )
+
+        attempt_record = {
+            "attempt": attempt,
+            "stop_reason": stop_reason,
+            "return_val": return_val,
+            "judge": judge_result,
+        }
+        all_attempts.append(attempt_record)
+
+        if judge_pass is True:
+            # Judge 确认通过
+            success = True
+            logger.info(f"✅ Judge 判定通过，共用 {attempt} 次 attempt")
+            break
+        elif judge_pass is False:
+            # Judge 确认失败
+            logger.warning(f"❌ Judge 判定失败（attempt {attempt}/{pass_count}）")
+            if attempt < pass_count:
+                logger.info("将重置环境后重试...")
+                continue
+        else:
+            # judge_pass is None → Judge 跳过（error / skip 模式），以 stop_reason 兜底
+            logger.warning(f"[Judge] 判定结果为 None，以 stop_reason={stop_reason} 兜底")
+            success = stop_reason.upper() == "COMPLETE"
+            break
+
+    if not success:
+        logger.warning(f"所有 {pass_count} 次 attempt 均未通过 Judge。")
+
+    return {
+        "success": success,
+        "attempts": len(all_attempts),
+        "stop_reason": last_stop_reason,
+        "return_val": last_return_val,
+        "judge": final_judge,
+        "all_attempts": all_attempts,
+    }

--- a/examples/run_single_task_with_judge.py
+++ b/examples/run_single_task_with_judge.py
@@ -1,0 +1,109 @@
+import sys
+import time
+
+if "." not in sys.path:
+    sys.path.append(".")
+
+from copilot_front_end.mobile_action_helper import list_devices, get_device_wm_size
+from copilot_agent_server.local_state_compress_server import LocalStateCompressServer
+from evaluate.runner import run_task_pass_at_n
+
+tmp_server_config = {
+    "log_dir": "running_log/server_log/os-copilot-local-eval-logs/traces",
+    "image_dir": "running_log/server_log/os-copilot-local-eval-logs/images",
+    "debug": False
+}
+
+local_model_config = {
+    "task_type": "parser_0920_summary_adv_state_compress",
+    "model_config": {
+        "model_name": "step-3.6",
+        "model_provider": "stepfun",
+        "args": {
+            "temperature": 1,
+            "top_p": 0.95,
+            "frequency_penalty": 0.05,
+            "max_tokens": 32768,
+        },
+    },
+    "config": {
+        "enable_state_compression": True,
+        "state_compression_interval": 10,
+        "state_compression_recent_window": 10,
+        "state_compression_max_field_items": 10,
+    },
+    "max_steps": 400,
+    "delay_after_capture": 3,
+    "debug": False,
+}
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python run_single_task.py \"your task\"")
+        sys.exit(1)
+
+    task = ' '.join(sys.argv[1:])
+
+    device_id = list_devices()[0]
+    device_wm_size = get_device_wm_size(device_id)
+    device_info = {
+        "device_id": device_id,
+        "device_wm_size": device_wm_size,
+    }
+
+    print(f"Device: {device_id}  wm_size: {device_wm_size}")
+    print(f"Task: {task}")
+    print("=" * 60)
+
+    l2_server = LocalStateCompressServer(tmp_server_config)
+
+    total_start = time.time()
+    result = run_task_pass_at_n(
+        agent_server=l2_server,
+        device_info=device_info,
+        task=task,
+        rollout_config=local_model_config,
+        pass_count=3,
+        judge_mode="auto",
+        # judge_criteria 留空，由 runner 根据 task 内容自动判断是否需要滑动检查
+        judge_criteria="",
+    )
+    total_time = time.time() - total_start
+
+    # ── 最终报告（独立分区，与 LLM 执行日志隔开）──────────────────────────
+    W = 60
+    print(f"\n{'#' * W}")
+    print(f"#{'EVALUATION REPORT':^{W-2}}#")
+    print(f"{'#' * W}")
+
+    # 基本信息
+    status_icon = "✅ SUCCESS" if result['success'] else "❌  FAIL  "
+    print(f"  状态      : {status_icon}")
+    print(f"  耗时      : {total_time:.1f}s  ({result['attempts']}/3 次 attempt)")
+    print(f"  stop      : {result['stop_reason']}")
+
+    # Agent 输出
+    print(f"\n  {'─'*54}")
+    print(f"  📤 Agent 输出")
+    print(f"  {'─'*54}")
+    agent_out = result['return_val'] or "(无)"
+    for line in agent_out.splitlines():
+        print(f"  {line}")
+
+    # Judge 判定
+    if result['judge']:
+        j = result['judge']
+        verdict_icon = "✅ pass" if j['verdict'] == "pass" else ("❌ fail" if j['verdict'] == "fail" else f"⚠️  {j['verdict']}")
+        print(f"\n  {'─'*54}")
+        print(f"  🔍 Judge 判定")
+        print(f"  {'─'*54}")
+        print(f"  verdict       : {verdict_icon}  (confidence={j['confidence']:.0%})")
+        print(f"  reason        : {j['reason']}")
+        print(f"  process_score : {j['process_score']:.1f}/1.0  {j['process_comment']}")
+        if j['analysis'].get('root_cause'):
+            print(f"  root_cause    : {j['analysis']['root_cause']}")
+        if j['analysis'].get('suggestions'):
+            for i, s in enumerate(j['analysis']['suggestions'], 1):
+                print(f"  suggestion {i}  : {s}")
+
+    print(f"{'#' * W}\n")

--- a/tools/ask_llm_v2.py
+++ b/tools/ask_llm_v2.py
@@ -45,7 +45,7 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
         ValueError: If ``model_provider`` is not found in ``model_config.yaml``.
     """
 
-    with open("model_config.yaml", "r") as f:
+    with open("model_config.yaml", "r", encoding="utf-8") as f:
         model_config = yaml.safe_load(f)
     
 
@@ -206,8 +206,8 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
     if not result.startswith("<think>") :
         print(f"Warning: LLM {model_name} returned response without reasoning content.", flush=True)
 
-
-    print(f"LLM {model_name} says:\n--------------start--------------\n{result}\n---------------end---------------",flush=True)
+    safe_result = result.encode("utf-8", errors="replace").decode(errors="replace")
+    print(f"LLM {model_name} says:\n--------------start--------------\n{safe_result}\n---------------end---------------", flush=True)
 
     return result
 

--- a/极简运行指南_CN.md
+++ b/极简运行指南_CN.md
@@ -260,3 +260,91 @@ http://localhost:33503
 5. 改 `examples/run_single_task_state_compress.py` 的 `model_provider` / `model_name`
 6. 运行 `python examples/run_single_task_state_compress.py --task "你的任务"`
 7. 运行 `streamlit run visualization/pages/main_page.py --server.port 33503`
+
+---
+
+## 6. Pass@N 评测入口（带 VLM Judge）
+
+除了 `run_single_task_state_compress.py`，本仓库还提供了 `examples/run_single_task_with_judge.py`，在原有执行能力基础上新增了两个核心功能：**Pass@N 重试** 和 **VLM Judge 自动判定**。
+
+### 6.1 功能概述
+
+| 功能 | 说明 |
+|------|------|
+| **Pass@N** | 每个任务最多执行 N 次（默认 3），Judge 判定通过即提前退出，节省不必要的重试 |
+| **VLM Judge** | 任务结束后自动调用 LLM，结合执行期截图和动作日志判断任务是否真正完成 |
+| **截图分叉** | Agent 每步截图同时保留一份给 Judge，Judge 看到的是 Agent 决策时的真实画面，而非事后补截 |
+| **场景自动检测** | 任务描述含"公众号/推文/文章"等关键词时，自动注入滑动阅读全文的约束和验收标准 |
+| **交叉核验** | Judge 对比截图实际内容与 Agent 返回值，捕捉读图幻觉类错误 |
+
+### 6.2 配置 model_config.yaml
+
+在原有 `stepfun` 配置基础上，新增 `judge` 节：
+
+```yaml
+stepfun:
+    api_base: "https://api.stepfun.com/v1"
+    api_key: "YOUR_API_KEY"
+
+# judge 独立一节，换模型只改 model_name，无需动代码
+judge:
+    api_base: "https://api.stepfun.com/v1"
+    api_key: "YOUR_API_KEY"
+    model_name: "step-3.6"
+```
+
+`judge` 可以和 `stepfun` 使用同一套 API，也可以指向不同服务商。
+
+### 6.3 运行
+
+```bash
+python examples/run_single_task_with_judge.py "你的任务描述"
+```
+
+示例：
+
+```bash
+python examples/run_single_task_with_judge.py "打开微信，查看通讯录第一个联系人的名字"
+python examples/run_single_task_with_judge.py "打开设置，查看当前手机型号"
+```
+
+### 6.4 输出说明
+
+任务执行过程日志（LLM 推理、每步动作）输出后，末尾会打印独立的评测报告：
+
+```
+############################################################
+#                   EVALUATION REPORT                     #
+############################################################
+  状态      : ✅ SUCCESS
+  耗时      : 48.2s  (1/3 次 attempt)
+  stop      : COMPLETE
+
+  📤 Agent 输出
+  ──────────────────────────────────────────────────────
+  打开设置后，当前手机型号为 XXX
+
+  🔍 Judge 判定
+  ──────────────────────────────────────────────────────
+  verdict       : ✅ pass  (confidence=100%)
+  reason        : 截图清晰显示榜单页面，返回值与截图一致
+  process_score : 1.0/1.0  执行路径高效，无冗余步骤
+############################################################
+```
+
+每步截图保存在：
+
+```
+running_log/server_log/os-copilot-local-eval-logs/images/{session_id}_step_{N}.jpeg
+```
+
+### 6.5 Judge 判定逻辑
+
+Judge 采用分级策略，按开销从低到高依次处理：
+
+1. **0 次 LLM**：ABORT、return_val 含失败关键词、要求滑动但无 SLIDE → 直接 fail
+2. **1 次 LLM（文本模式）**：COMPLETE 但无截图 → 纯文本判定
+3. **1 次 LLM（视觉模式）**：COMPLETE + 有截图 → 全量 VLM，截图与返回值交叉核验
+
+Judge 模型调用失败时自动重试最多 3 次，全部失败则以 `stop_reason` 兜底。
+


### PR DESCRIPTION
新增评测模块 evaluate/，为任务执行引入 Pass@N 重试和 VLM Judge 自动判定能力：

- evaluate/runner.py：Pass@N 调度器，每次 attempt 后立即运行 Judge， Judge=pass 提前退出，Judge=fail 触发重试；自动检测阅读全文场景并注入 滑动约束，Judge model 名统一从 model_config.yaml 读取，代码零硬编码

- evaluate/judge.py：VLM Judge 核心，分级判定（ABORT/关键词→0次LLM， 有截图→全量VLM），截图与返回值交叉核验捕捉读图幻觉，LLM 调用失败 自动重试最多3次

- pu_client.py：截图分叉，每步截图同时缓存给 Judge（滚动保留最后5张）， return_log 新增 last_step_screenshot / history_actions / return_val， Judge 使用执行期真实截图而非事后延迟补截

- examples/run_single_task.py：接入新入口，终端报告独立分区展示 Agent 输出和 Judge 判定结果

- tools/ask_llm_v2.py：print 加 utf-8 容错，避免 Windows GBK 终端异常

- 极简运行指南_CN.md：补充第6节 Pass@N 评测入口使用说明