### PR TITLE
fix(parser): handle multiple THINK blocks from reasoning models

### DIFF
--- a/copilot_tools/parser_0920_summary.py
+++ b/copilot_tools/parser_0920_summary.py
@@ -265,11 +265,23 @@ class Parser0920Summary():
         
         # Extract CoT and key-value parts
         # Expected format: <THINK> cot </THINK>\nexplain:xxx\taction:xx\tvalue:xxx\tsummary:xxx
+        # Note: Some models (e.g. step-3.7-flash via Chat Completions API) may output
+        # multiple THINK blocks (reasoning_content wrapped as <think> + model's own <THINK>).
+        # We take the LAST </THINK> as the boundary so kv_part always starts after all THINK blocks.
         try:
-            cot_part = command_str.split("<THINK>")[1].split("</THINK>")[0].strip()
-            kv_part = command_str.split("</THINK>")[1].strip()
-        except IndexError:
-            print(f"[Parser Warning] Missing <THINK> tags, treating entire response as kv")
+            think_ends = list(re.finditer(r"</THINK>", command_str, flags=re.IGNORECASE))
+            if think_ends:
+                think_starts = list(re.finditer(r"<THINK>", command_str, flags=re.IGNORECASE))
+                if think_starts:
+                    cot_part = command_str[think_starts[0].end():think_ends[0].start()].strip()
+                else:
+                    cot_part = ""
+                kv_part = command_str[think_ends[-1].end():].strip()
+            else:
+                kv_part = command_str
+                cot_part = ""
+        except Exception:
+            print(f"[Parser Warning] THINK tag parsing issue, treating entire response as kv")
             kv_part = command_str
             cot_part = ""
 

--- a/tools/ask_llm_v2.py
+++ b/tools/ask_llm_v2.py
@@ -173,37 +173,34 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
     print("llm ask id:", completion.id)
 
     # Some providers return reasoning content in a dedicated field.
-
-    # print(completion.choices[0].message.reasoning, flush=True)
-    # input()
+    # We log it for debugging but do NOT prepend it to the result.
+    # Prepending reasoning_content as a <think> block causes issues when the
+    # model's content already contains <THINK> tags (required by the parser prompt),
+    # resulting in two layers of THINK tags that confuse str2action().
+    # The parser only needs the model's content output, which already follows
+    # the <THINK>...</THINK>\texplain:...\taction:...\tsummary:... format.
 
     llm_content = completion.choices[0].message.content
     result = llm_content
     if llm_content is None or len(llm_content) == 0:
         llm_content = ""
+        result = ""
         print(f"Warning: LLM {model_name} returned empty content.", flush=True)
     
+    reasoning_debug = None
     try:
-        reasoning = completion.choices[0].message.reasoning_content
-        if reasoning is not None and len(reasoning) > 0:
-            result = "<think>" + reasoning + "</think>" + "\n" + llm_content
+        reasoning_debug = completion.choices[0].message.reasoning_content
     except Exception:
-        # for common llm that doesn't have reasoning_content field
-        # print(f"LLM {model_name} does not have reasoning_content field, skipping.", flush=True)
         pass
+    if reasoning_debug is None:
+        try:
+            reasoning_debug = completion.choices[0].message.reasoning
+        except Exception:
+            pass
 
-    try:
-        reasoning = completion.choices[0].message.reasoning
-        if reasoning is not None and len(reasoning) > 0:
-            result = "<think>" + reasoning + "</think>" + "\n" + llm_content
-        else:
-            raise AttributeError("No reasoning content field found")
-    except Exception as e:
-        # for common llm that doesn't have reasoning_content field
-        # print(f"LLM {model_name} does not have reasoning field, skipping.", flush=True)
-        pass
-
-    if not result.startswith("<think>") :
+    if reasoning_debug and len(reasoning_debug) > 0:
+        print(f"[Reasoning] {reasoning_debug[:200]}...", flush=True)
+    else:
         print(f"Warning: LLM {model_name} returned response without reasoning content.", flush=True)
 
 


### PR DESCRIPTION
## Problem

Fixes #62

When using cloud reasoning models (e.g. `step-3.7-flash`) via Chat Completions API, the parser fails with `ValueError: ui_action must contain 'action' or 'action_type'`.

### Three API Comparison

Tested all three StepFun API types — the two-layer THINK problem **only occurs with Chat Completions API**:

| API | Reasoning Location | Content Output | Two-layer THINK? |
|-----|-------------------|----------------|:---:|
| **Chat Completions** | `reasoning_content` field | 1 layer `<THINK>` in content | ⚠️ Yes — `ask_llm_v2.py` prepends it |
| **Messages** (Anthropic) | `thinking` type block | 1 layer `<THINK>` in text block | No |
| **Responses** | `reasoning` type output item | 1 layer `<THINK>` in message | No |

The model's `content` always has exactly one `<THINK>` layer (as required by the prompt). The problem is `ask_llm_v2.py` wrapping `reasoning_content` as a second `<think>` block.

## Fix (two changes)

### Commit 1: `ask_llm_v2.py` — Root cause fix

Stop prepending `reasoning_content` to the result. The reasoning content is now logged for debugging but no longer injected into the output. The model's `content` is returned as-is, which already follows the expected `<THINK>...</THINK>	explain:...	action:...	summary:...` format.

### Commit 2: `parser_0920_summary.py` — Defensive fix

Handle multiple THINK blocks gracefully by taking the **last** `</THINK>` as the boundary for `kv_part` extraction. This ensures robustness even if some other code path produces multi-layer THINK tags.

## Verification

Tested with `step-3.7-flash` controlling a real Android device (iQOO Z9 Turbo+):

| Task | Steps | Result |
|------|-------|--------|
| Open Settings > About Phone > read model info | 5 steps | Completed successfully |
| Open WeChat > find and open specific group chat | 7 steps | Completed successfully |

Both tasks failed before the fix (parser error on first step) and succeeded after.
