### PR TITLE
fix: 不再把 reasoning_content 拼接到模型输出前面

### DIFF
--- a/tools/ask_llm_v2.py
+++ b/tools/ask_llm_v2.py
@@ -173,39 +173,32 @@ def ask_llm_anything(model_provider, model_name, messages, args= {
     print("llm ask id:", completion.id)
 
     # Some providers return reasoning content in a dedicated field.
-
-    # print(completion.choices[0].message.reasoning, flush=True)
-    # input()
+    # We log it for debugging but do NOT prepend it to the result.
+    # Prepending reasoning_content as <think> creates two layers of THINK tags
+    # when the model's content already contains <THINK> (required by the parser prompt),
+    # which causes str2action() to fail parsing the key-value pairs.
 
     llm_content = completion.choices[0].message.content
-    result = llm_content
-    if llm_content is None or len(llm_content) == 0:
-        llm_content = ""
+    result = llm_content if llm_content else ""
+
+    if not llm_content:
         print(f"Warning: LLM {model_name} returned empty content.", flush=True)
-    
+
+    reasoning_debug = None
     try:
-        reasoning = completion.choices[0].message.reasoning_content
-        if reasoning is not None and len(reasoning) > 0:
-            result = "<think>" + reasoning + "</think>" + "\n" + llm_content
+        reasoning_debug = completion.choices[0].message.reasoning_content
     except Exception:
-        # for common llm that doesn't have reasoning_content field
-        # print(f"LLM {model_name} does not have reasoning_content field, skipping.", flush=True)
         pass
+    if not reasoning_debug:
+        try:
+            reasoning_debug = completion.choices[0].message.reasoning
+        except Exception:
+            pass
 
-    try:
-        reasoning = completion.choices[0].message.reasoning
-        if reasoning is not None and len(reasoning) > 0:
-            result = "<think>" + reasoning + "</think>" + "\n" + llm_content
-        else:
-            raise AttributeError("No reasoning content field found")
-    except Exception as e:
-        # for common llm that doesn't have reasoning_content field
-        # print(f"LLM {model_name} does not have reasoning field, skipping.", flush=True)
-        pass
-
-    if not result.startswith("<think>") :
+    if reasoning_debug:
+        print(f"[Reasoning] {reasoning_debug[:200]}...", flush=True)
+    else:
         print(f"Warning: LLM {model_name} returned response without reasoning content.", flush=True)
-
 
     print(f"LLM {model_name} says:\n--------------start--------------\n{result}\n---------------end---------------",flush=True)
 


### PR DESCRIPTION
## 问题

Fixes #62

用 Chat Completions 接口跑云端推理模型（比如 `step-3.7-flash`）时，parser 在第一步就挂了：

```
ValueError: ui_action must contain 'action' or 'action_type'. Got keys: ['cot']
```

### 根因

`ask_llm_v2.py` 检测到 API 响应里的 `reasoning_content`，就把它包成一个 `<think>` 块拼到模型 `content` 前面：

```python
result = "<think>" + reasoning + "</think>" + "\n" + llm_content
```

但模型的 `content` 本身已经带了 `<THINK>` 标签（parser 提示词要求的），这样就叠成了两层：

```
<think>API 返回的 reasoning_content</think>      ← ask_llm_v2.py 拼上去的
<THINK>模型自己的思考</THINK>                    ← 来自模型 content
explain:...  action:CLICK  point:500,300  ...    ← parser 真正要的这段
```

parser 的 `str2action()` 用 `split("</THINK>")[1]` 取键值段，取到的是**第一个** `</THINK>` 之后的内容，也就是第二层 THINK 的正文，而不是动作参数。

### 三接口对比

| 接口 | 推理内容位置 | 是否两层 THINK |
|-----|-------------------|:---:|
| Chat Completions | `reasoning_content` 字段，被 `ask_llm_v2.py` 拼接 | 是 |
| Messages (Anthropic) | 独立的 `thinking` 类型块 | 否 |
| Responses | 独立的 `reasoning` 类型 output item | 否 |

模型的 `content` 永远只有一层 `<THINK>`。问题完全出在 `ask_llm_v2.py` 的处理上。

## 修复

不再把 `reasoning_content` 拼到结果前面。保留它做调试日志，直接返回 `content` 本身。`content` 已经符合 `<THINK>...</THINK>\texplain:...\taction:...\tsummary:...` 的格式。

只改了 `tools/ask_llm_v2.py` 一个文件（19 增 26 删）。

## 验证

用 `step-3.7-flash` 控制真机（iQOO Z9 Turbo+）测过：

| 任务 | 步数 | 结果 |
|------|-------|------|
| 打开 设置 > 关于手机 > 读取型号信息 | 5 步 | 成功完成 |
| 打开微信 > 找到并进入指定群聊 | 5 步 | 成功完成 |

两个任务在修复前都会在第一步 parser 报错，修复后都跑通了。
